### PR TITLE
Created_at frontend issue hotfix

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -1,6 +1,5 @@
 from pydantic import BaseModel
 from typing import Optional, List
-from datetime import datetime
 
 class Hint(BaseModel):
     hint: str
@@ -11,7 +10,6 @@ class CreateChallengeRequest(BaseModel):
     points: int
     creator_name: str
     division: List[int]
-    created_at: datetime
     challenge_description: str
     flag: str
     is_flag_case_sensitive: bool


### PR DESCRIPTION
This is a hotfix for the issue, where it requires the frontend to pass the created_at property. Now, it doesnt require it but still allows it to pass it as a property, so we can still use our previous tests. Note: This property from the frontend was never used for the actual created_at in the db, that was always generated in the backend.