### PR TITLE
Added endpoints for updating and deleting challenges

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -28,6 +28,7 @@ protected_paths = {
     "/challenges/get": ["admin","crimson_defense"],
     "/competitions/get/current": ["teacher"],
     "/competitions/get": ["admin"],
+    "/challenges/<string:challenge_id>" : ["admin", "crimson_defense"], 
 }
 
 def path_matches(pattern, path):


### PR DESCRIPTION
Tested with CURL requests. I've included them below.
1.) Updating Challenge:
`curl -X PUT http://127.0.0.1:3001/challenges/65f1a2b3c4d5e6f7g8h9i0j1 \
  -H "Content-Type: application/json" \
  --cookie "access_token=<access_token>" \
  -d '{
    "challenge_name": "SQL Injection Advanced",
    "points": 150,
    "creator_name": "John Doe",
    "division": [2, 3],
    "challenge_description": "Find the flag using advanced SQL injection techniques",
    "flag": "flag{sql_injection_expert}",
    "is_flag_case_sensitive": true,
    "challenge_category": "web",
    "verified": true,
    "solution_explanation": "Use blind SQL injection techniques",
    "hints": [
      {
        "hint": "Look for time-based injection",
        "point_cost": 15
      },
      {
        "hint": "Consider using UNION queries",
        "point_cost": 25
      }
    ]
  }'`
2.)Delete Challenge:
`curl -X DELETE http://127.0.0.1:3001/challenges/65f1a2b3c4d5e6f7g8h9i0j1 \
  -H "Content-Type: application/json" \
  --cookie "access_token=<access_token>"`