### PR TITLE
Added report for student accounts and practice accounts

### DIFF
--- a/api/middleware.py
+++ b/api/middleware.py
@@ -34,7 +34,8 @@ protected_paths = {
     "/teams/get": ["admin", "teacher"],
     "/teachers/get/all": ["admin"],
     "/teams/<string:team_id>": ["admin", "teacher"],
-    "/reports/teams/info/create": ["admin"]
+    "/reports/teams/info/create": ["admin"],
+    "/reports/students/create": ["admin"],
 }
 
 def path_matches(pattern, path):

--- a/api/models.py
+++ b/api/models.py
@@ -142,3 +142,8 @@ class ForgotPasswordRequest(BaseModel):
 class CreateTeamsReportRequest(BaseModel):
     is_virtual: bool
     email: Optional[str] = None
+
+class CreateStudentAccountsReportRequest(BaseModel):
+    email: Optional[str] = None
+    is_verified: Optional[bool] = True
+

--- a/api/routes/reports.py
+++ b/api/routes/reports.py
@@ -5,7 +5,7 @@ from pymongo.errors import WriteError, OperationFailure
 from datetime import datetime
 from pydantic import ValidationError
 from bson.objectid import ObjectId
-from models import CreateTeamsReportRequest
+from models import CreateTeamsReportRequest, CreateStudentAccountsReportRequest
 import logging
 from emails import EmailWithAttachmentRequest, send_email_with_attachment
 import jwt
@@ -27,6 +27,8 @@ db_teams_collection: str = current_app.config['DB_TEAMS_COLLECTION']
 db_accounts_collection: str = current_app.config['DB_ACCOUNTS_COLLECTION']
 db_students_collection: str = current_app.config['DB_STUDENT_INFO_COLLECTION']
 db_teachers_collection: str = current_app.config['DB_TEACHER_INFO_COLLECTION']
+db_student_accounts_collection: str = current_app.config['DB_STUDENT_ACCOUNTS_COLLECTION']
+db_team_accounts_collection: str = current_app.config["DB_TEAM_ACCOUNTS_COLLECTION"]
 
 @reports_blueprint.route('/reports/teams/info/create', methods=["POST"])
 def create_teams_info_report() -> Tuple[Response, int]:
@@ -93,9 +95,7 @@ def create_teams_info_report() -> Tuple[Response, int]:
         ]
         writer.writerow(headers)
 
-        # Process each team
         for team in teams_of_type:
-            # Get teacher info
             teacher = teachers_collection.find_one({"_id": ObjectId(team["teacher_id"])})
             if not teacher:
                 logging.error(f"Teacher not found for team {team['_id']}")
@@ -103,10 +103,8 @@ def create_teams_info_report() -> Tuple[Response, int]:
             team_id = team.get("_id")
             team_id = ObjectId(team_id)
 
-            # Get students for this team
             students = students = list(student_collection.find({"team_id":ObjectId(team["_id"])}).limit(4))
-            
-            # Prepare row data
+
             row = [
                 f"{teacher['first_name']} {teacher['last_name']}",
                 ", ".join(str(d) for d in team["division"]),
@@ -117,7 +115,6 @@ def create_teams_info_report() -> Tuple[Response, int]:
                 teacher["shirt_size"]
             ]
             
-            # Add student information (up to 4 students)
             for i in range(4):
                 if i < len(students):
                     student = students[i]
@@ -170,5 +167,153 @@ The Team
         logging.error("Encountered exception: %s", e)
         return jsonify({'error': "Internal Server Error. Check server logs for details."}), status.INTERNAL_SERVER_ERROR
 
+
+@reports_blueprint.route('/reports/students/create', methods=["POST"])
+def create_student_accounts_report() -> Tuple[Response, int]:
+    try:
+        create_student_accounts_report_request: CreateStudentAccountsReportRequest = CreateStudentAccountsReportRequest.model_validate_json(request.data)
+        create_student_accounts_report_dict: Dict = create_student_accounts_report_request.model_dump()
+        
+        db = client[db_name]
+        student_accounts_collection = db[db_student_accounts_collection]
+        student_info_collection = db[db_students_collection]
+        accounts_collecion = db[db_accounts_collection]
+
+        admin_email = create_student_accounts_report_dict["email"]
+        if admin_email == None:
+            token = request.cookies.get("access_token")
+            if token:
+                decoded_token = jwt.decode(token, secret_key, algorithms=[auth_algorithm])
+            else:
+                logging.error("Unable to get token from cookies")
+                return jsonify({"error": "Internal Server Error. Check Server Logs"}), status.INTERNAL_SERVER_ERROR
+            if not decoded_token:
+                logging.error("Unable to decode token")
+                return jsonify({"error": "Internal Server Error. Check Server Logs"}), status.INTERNAL_SERVER_ERROR
+
+            admin_id = decoded_token["userId"]
+            admin_info = accounts_collecion.find_one({"_id": ObjectId(admin_id)})
+            if admin_info is None:
+                return jsonify({"error": "Error getting admin info from server. Alternatively, try providing your email address directly."}), status.INTERNAL_SERVER_ERROR
+            admin_email = admin_info["email"]
+        
+        student_verification_type = create_student_accounts_report_dict["is_verified"]
+        students_of_requested_type = list(student_info_collection.find({"is_verified": student_verification_type}))
+        if not students_of_requested_type:
+            return jsonify({"error": "Could not find students of requested verification status"}), status.INTERNAL_SERVER_ERROR
+
+        output = io.StringIO()
+        writer = csv.writer(output)
+        
+        practice_output = io.StringIO()
+        practice_writer = csv.writer(practice_output)
+
+        headers = [
+            "name",
+            "email",
+            "password",
+        ]
+
+        practice_headers = [
+            "username",
+            "password"
+        ]
+
+        writer.writerow(headers)
+        practice_writer.writerow(practice_headers)
+
+        for student in students_of_requested_type:
+            student_id = student.get("_id")
+            student_email = student["email"]
+            student_account = student_accounts_collection.find_one({"student_info_id": ObjectId(student_id)})
+            if not student_account:
+                continue
+            password = student_account["competition_password"]
+            practice_username = student_account["practice_username"]
+            practice_password = student_account["practice_password"]
+
+            row = [
+                f"{student['first_name']} {student['last_name']}",
+                student_email,
+                password
+            ]
+
+            practice_row = [
+                practice_username,
+                practice_password
+            ]
+
+            writer.writerow(row)
+            practice_writer.writerow(practice_row)
+
+        output.seek(0)
+        content = output.getvalue()
+
+        practice_output.seek(0)
+        practice_content = practice_output.getvalue()
+
+        if content.count('\n') <= 1:
+            return jsonify({'error': 'No valid student accounts could be processed for the report.'}), status.NOT_FOUND
+
+        if practice_content.count('\n') <= 1:
+            return jsonify({'error': 'No valid practice accounts for the requested students could be processed for the report.'}), status.NOT_FOUND
+
+        if student_verification_type:
+            report_type = "Verified"
+        else:
+            report_type = "Unverified"
+
+        email_request = EmailWithAttachmentRequest(
+            email_account=admin_email,
+            subject=f"{report_type} Student Accounts Report",
+            message=f"""
+Dear Admin,
+
+Attached is the {report_type} Student Accounts Report you requested.
+
+Best regards,
+The Team
+            """.strip(),
+            attachment_content=base64.b64encode(content.encode()).decode(),
+            attachment_filename=f"{report_type}_student_accounts_report.csv"
+        )
+
+        email_sent = send_email_with_attachment(email_request)
+        if not email_sent:
+            logging.error(f"Failed to send report email to {admin_email}")
+            return jsonify({'error': 'Failed to send email with report'}), status.INTERNAL_SERVER_ERROR
+
+        practice_email_request = EmailWithAttachmentRequest(
+            email_account=admin_email,
+            subject=f"Practice Accounts Report",
+            message=f"""
+Dear Admin,
+
+Attached is the Practice Accounts Report you requested.
+
+Best regards,
+The Team
+            """.strip(),
+            attachment_content=base64.b64encode(practice_content.encode()).decode(),
+            attachment_filename=f"practice_student_accounts_report.csv"
+        )
+
+        practice_email_sent = send_email_with_attachment(practice_email_request)
+        if not practice_email_sent:
+            logging.error(f"Failed to send practice accounts report email to {admin_email}")
+            return jsonify({'error': 'Failed to send email with report'}), status.INTERNAL_SERVER_ERROR
+
+
+        return jsonify({"content":"Successfully generated and sent the student accounts report"}), status.OK
+
+    except ValidationError as e:
+         return jsonify({'error': str(e)}), status.BAD_REQUEST
+    except OperationFailure as e:
+        logging.error("OperationFailure: %s", e)
+        return jsonify({'error': 'Database operation failed due to an internal error.'}), status.INTERNAL_SERVER_ERROR
+
+    except Exception as e:
+        logging.error("Encountered exception: %s", e)
+        return jsonify({'error': "Internal Server Error. Check server logs for details."}), status.INTERNAL_SERVER_ERROR
 
 


### PR DESCRIPTION
- Generates a report for student accounts of the requested verification status (is_verified=True or is_verified=False)
- Also sends the practice accounts as a separate email (we dont have the ability to send multiple attachments in an email in the email service. I didn't think it was practical to create a separate functionality for that given our time constraints).
- Note: Since we dont have any verified students or verification system yet, sending a request with 'is_verified'=True returns an error. So, I recommend using is_verified=False whenever you call the endpoint.